### PR TITLE
[fixes #15] cut down plugin update notes

### DIFF
--- a/Commands/SitesMassWordPressUpdateCommand.php
+++ b/Commands/SitesMassWordPressUpdateCommand.php
@@ -2,6 +2,7 @@
 
 namespace Terminus\Commands;
 
+
 use Terminus\Models\Auth;
 use Terminus\Collections\Sites;
 use Terminus\Commands\TerminusCommand;
@@ -587,7 +588,10 @@ class MassWordPressUpdateCommand extends TerminusCommand {
 			$date = new \DateTime();
 
 			$slack_notif_text = "";
+
 			$slack_notif_text .= "*Terminus update on " . $name . "*\n\n";
+
+			$update_report = $this->getUpdateNotes( $update_report );
 
 			if ( $update_report ) {
 
@@ -1022,6 +1026,36 @@ class MassWordPressUpdateCommand extends TerminusCommand {
 		}
 
 		return $slack_settings;
+
+	}
+
+
+	/**
+	* Parse update notes to array table
+	*
+	*/
+	private function getUpdateNotes( $update_notes ) {
+
+		require_once( 'lib/Update_Translator.php' );
+
+		$data = new \Update_Translator( $update_notes );
+
+		return $data->table_reports;
+
+	}
+
+
+	/**
+	* Parse update notes to get keyed array
+	*
+	*/
+	private function getUpdateData( $update_notes ) {
+
+		require_once( 'lib/Update_Translator.php' );
+
+		$data = new \Update_Translator( $update_notes );
+
+		return $data->data;
 
 	}
 

--- a/Commands/lib/Update_Translator.php
+++ b/Commands/lib/Update_Translator.php
@@ -1,0 +1,98 @@
+<?php 
+
+if ( class_exists( 'Update_Translator' ) ) return;
+
+class Update_Translator {
+
+
+	public $data = array();
+
+	
+	public $table_reports;
+
+	
+	public function __construct( $update_notes ) {
+
+
+		// 	Filter for update table
+		$table = array();
+
+		foreach ( $update_notes as $update_note ) {
+
+			$note = $this->parse_line( $update_note );
+
+			if ( $note ) {
+
+				$table[] = $note;
+
+			}
+
+		}
+
+		if ( $table ) {
+
+			// 	Get plugin update notes
+			$table = array_splice( $table, 1 );
+
+			$table_data = array();
+
+			$table_array = array();
+
+			foreach ( $table as $value ) {
+
+				$text = ltrim( $value, '|' );
+
+				$text = rtrim( $text, '|' );
+
+				$text = trim(preg_replace('/\s\s+/', ' ', str_replace("\n", " ", $text)));
+
+				$table_data[] = explode( ' | ', $text );
+
+			}
+
+			foreach ( $table_data as $key => $value ) {
+
+				$table_array[] = array(
+					'name'			=> $value[0],
+					'old_version'	=> $value[1],
+					'new_version'	=> $value[2],
+					'status'		=> $value[3],
+				);
+
+			}
+
+			// Save parsed data
+			$this->data = $table_array;
+
+		}
+
+
+	}
+
+
+	public function parse_line( $str ) {
+
+		$line = false;
+
+		if ( $str[0] === '|' ) {
+
+			$str = trim( $str, ' ' );
+
+			$line = $str;
+
+		}
+
+		if ( $str[0] === '|' || $str[0] === '+' ) {
+
+			$str = trim( $str, ' ' );
+
+			$this->table_reports[] = $str;
+
+		}
+
+		return $line;
+
+	}
+
+
+}


### PR DESCRIPTION
Added a function to output smaller update message.

```
// when table format is needed
$this->getUpdateNotes( $update_notes );

// when keyed array data is needed
$this->getUpdateData( $update_notes );
```
